### PR TITLE
Add `flycheck-status-emoji` package

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -36,3 +36,6 @@ The following extensions provide additional cool features for Flycheck:
 - [flycheck-rust](https://github.com/flycheck/flycheck-rust) improves Rust
   support in Flycheck, by configuring Flycheck according to Cargo settings and
   layouts.
+- [flycheck-status-emoji](https://github.com/liblit/flycheck-status-emoji)
+  replaces mode-line status with cute, compact emoji, such as `😱` for
+  errors or `😌` if no problems were found.


### PR DESCRIPTION
This change is to let you and your user community know about my [`flycheck-status-emoji`](https://github.com/liblit/flycheck-status-emoji) package. Of course you are welcome to rephrase my concise summary, but I’d be honored if you included this in the extensions list in some form or another. Thanks!