### PR TITLE
Update extensions.md

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -60,3 +60,6 @@ extension here, please feel free to [add it][].
   emacs lisp package source code for common problems.
 * [flycheck-pyflakes](https://github.com/Wilfred/flycheck-pyflakes) adds a
   Python syntax checker using Pyflakes.
+* [flycheck-hdl-irun](https://github.com/cmarqu/flycheck-hdl-irun) adds a 
+  syntax checker for hardware description languages (HDLs) supported by 
+  Cadence irun.

--- a/extensions.md
+++ b/extensions.md
@@ -46,6 +46,9 @@ extension here, please feel free to [add it][].
   fly.
 * [flycheck-google-cpplint](https://github.com/flycheck/flycheck-google-cpplint)
   (*official*) adds a syntax checker for Google's C++ style checker.
+* [flycheck-hdl-irun](https://github.com/cmarqu/flycheck-hdl-irun) adds a
+  syntax checker for hardware description languages (HDLs) supported by
+  [Cadence IES/irun](http://www.cadence.com/products/fv/enterprise_simulator/pages/default.aspx).
 * [flycheck-irony](https://github.com/Sarcasm/flycheck-irony) adds a Flycheck
   syntax checker for C, C++ and Objective C using
   [Irony Mode](https://github.com/Sarcasm/irony-mode).
@@ -60,6 +63,3 @@ extension here, please feel free to [add it][].
   emacs lisp package source code for common problems.
 * [flycheck-pyflakes](https://github.com/Wilfred/flycheck-pyflakes) adds a
   Python syntax checker using Pyflakes.
-* [flycheck-hdl-irun](https://github.com/cmarqu/flycheck-hdl-irun) adds a 
-  syntax checker for hardware description languages (HDLs) supported by 
-  Cadence irun.

--- a/manual/latest/Defining-syntax-checkers.html
+++ b/manual/latest/Defining-syntax-checkers.html
@@ -169,8 +169,8 @@ digits as line and column respectively of the error.
 of supported forms.
 </p>
 </li><li> The <code>:modes</code> property denotes the major modes, in which Flycheck
-may use this syntax checker.  <code>pylint</code> checks Javascript, so the
-<code>:modes</code> of our example specify <code>python-mode</code>.
+may use this syntax checker.  <code>rubocop</code> checks Ruby code, so the
+<code>:modes</code> of our example specify <code>ruby-mode</code> and <code>enh-ruby-mode</code>.
 
 </li></ul>
 


### PR DESCRIPTION
Add link to https://github.com/cmarqu/flycheck-hdl-irun which adds a syntax checker for hardware description languages (HDLs) supported by Cadence irun.